### PR TITLE
Routing Extension Spec

### DIFF
--- a/Extensions/CompositeMetadata.md
+++ b/Extensions/CompositeMetadata.md
@@ -46,4 +46,4 @@ This metadata type is intended to be used per stream, and not per connection nor
 [rf]: https://tools.ietf.org/html/rfc2045
 [s]:  http://www.iana.org/assignments/media-type-structured-suffix/media-type-structured-suffix.xml
 [tz]: Tracing-Zipkin.md
-[wk]: Well-Known-MIME-Types.md
+[wk]: WellKnownMimeTypes.md

--- a/Extensions/Routing.md
+++ b/Extensions/Routing.md
@@ -1,0 +1,30 @@
+# Routing Metadata Extension
+
+_This extension specification is currently incubating.  While incubating the version is 0._
+
+## Introduction
+When two system are communicating via RSocket, there are often logical divisions in the messages that are sent from the requester to the responder.  These logical divisions can often be implemented by the responder as "routes" for messages to be sent to.  This extension specification provides an interoperable structure for metadata payloads to contain routing information.  It is designed such that an arbitrary collection of tags (strings) can be used by the responder to route messages and any individual tag (or all included tags) can be ignored.
+
+## Metadata Payload
+This metadata type is intended to be used per stream, and not per connection nor individual payloads and as such it **MUST** only be used in frame types used to initiate interactions.  This includes [`REQUEST_FNF`][rf], [`REQUEST_RESPONSE`][rr], [`REQUEST_STREAM`][rs], and [`REQUEST_CHANNEL`][rc].  The Metadata MIME Type is `message/x.rsocket.routing.v0`.
+
+[rc]: ../Protocol.md#frame-request-channel
+[rf]: ../Protocol.md#frame-fnf
+[rr]: ../Protocol.md#frame-request-response
+[rs]: ../Protocol.md#frame-request-stream
+
+### Metadata Contents
+```
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |  Tag Length   |              Tag                             ...
+    +---------------+-----------------------------------------------+
+    |  Tag Length   |              Tag                             ...
+    +---------------+-----------------------------------------------+
+                                   ...
+```
+
+* **Tag Payload**: Any number of complete tag payloads.
+  * **Tag Length**: Tag Length in bytes.
+  * **Tag**:  Token used for routing.  The string MUST NOT be null terminated.  Examples include URI-style routes (`/person`, `/address`), or artibrary metadata (`ios-client`, `android-client`).

--- a/Extensions/WellKnownMimeTypes.md
+++ b/Extensions/WellKnownMimeTypes.md
@@ -48,4 +48,5 @@ All well-known MIME types assume UTF-8 character encoding wherever a character s
 | `video/VP8` | `37`
 | |
 | `message/x.rsocket.tracing-zipkin.v0` | `125`
+| `message/x.rsocket.routing.v0` | `126`
 | `message/x.rsocket.composite-metadata.v0` | `127`

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Artifacts include:
 
 - [RSocket Protocol](Protocol.md)
 - Protocol Extensions
-  - [Well-known MIME Types](Extensions/Well-Known-MIME-Types.md)
+  - [Well-known MIME Types](Extensions/WellKnownMimeTypes.md)
   - [Composite Metdata](Extensions/CompositeMetadata.md)
+  - [Routing](Extensions/Routing.md)
   - [Tracing (Zipkin)](Extensions/Tracing-Zipkin.md)
 - [Motivation for creating this protocol](Motivations.md)
 - [Frequently Asked Questions](FAQ.md)


### PR DESCRIPTION
This change adds an extension specification for routing that allows arbitrary
tags to be included by the requestor for the responder to use for message
routing.

> When two system are communicating via RSocket, there are often logical divisions in the messages that are sent from the requestor to the responder.  These logical divisions can often be implemenated by the responder as "routes" for messages to be sent to.  This extension specification provides an interoperable structure for metadata payloads to contain routing information.  It is designed such that an arbitrary collection of tags can be used by the responder to route messages and any individual tag (or all included tags) can be ignored.