### PR TITLE
Tracing (Zipkin)

### DIFF
--- a/Extensions/Tracing-Zipkin.md
+++ b/Extensions/Tracing-Zipkin.md
@@ -1,0 +1,54 @@
+# Tracing (Zipkin) Metadata Extension
+
+_This extension specification is currently incubating.  While incubating the version is 0._
+
+## Introduction
+Observability and tracing are key requirements for robust and reliable applications.  When using distributed applications connected with RSocket, it's important to propagate metadata about the current logical operations throughout the entire system.  One of the most popular systems for doing this kind of tracing is [Zipkin][z].  This extension specification provides an interoperable structure for Zipkin metadata payloads to contain tracing information.  It is designed such that systems can efficently communicate span and trace information to a Zipkin server and propagate that information throughout a distributed system.
+
+[z]: https://zipkin.io
+
+## Metadata Payload
+This metadata type is intended to be used per stream, and not per connection nor individual payloads and as such it  **MUST** only be used in frame types used to initiate interactions and payloads.  This includes [`REQUEST_FNF`][rf], [`REQUEST_RESPONSE`][rr], [`REQUEST_STREAM`][rs], [`REQUEST_CHANNEL`][rc], and [`PAYLOAD`][p].  The Metadata MIME Type is `message/x.rsocket.tracing-zipkin.v0`.
+
+[p]:  ../Protocol.md#frame-payload
+[rc]: ../Protocol.md#frame-request-channel
+[rf]: ../Protocol.md#frame-fnf
+[rr]: ../Protocol.md#frame-request-response
+[rs]: ../Protocol.md#frame-request-stream
+
+### Metadata Contents
+```
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |P|S  |D  |     |
+    +-+---+---+-----------------------------------------------------+
+    |                                                               |
+    +                                                               +
+    |                                                               |
+    +                           Trace ID                            +
+    |                                                               |
+    +                                                               +
+    |                                                               |
+    +---------------------------------------------------------------+
+    |                                                               |
+    +                           Span ID                             +
+    |                                                               |
+    +---------------------------------------------------------------+
+    |                                                               |
+    +                        Parent Span ID                         +
+    |                                                               |
+    +---------------------------------------------------------------+
+```
+
+* **Flags**: (8 bits)
+  * (**P**)arent Span Id: Tracing payload contains a parent span id.
+  * (**S**)ampling Decision (2 bits): Tracing payload contains a sample value. (Exclusive with D flag.)
+    * First bit indicates if a sampling decision is present
+    * Second bit indicates that the span should be reported to the tracing system. (Not present if first bit is not set)
+  * (**D**)ebug (2 bits): Tracing payload contains a debug value. (Exclusive with S flag.)
+    * First bit indicates if a debug decision is present
+    * Second bit indicates that the trace should be reported to the tracing system and also override any collection-tier sampling policy. Debug implies an accept sampling decision. (Not present if the first bit is not set)
+* **Trace ID**: (128 bits) Unsigned 128-bit integer ID of the trace. Every span in a trace shares this ID.
+* **Span ID**: (64 bits) Unsigned 64-bit integer ID for a particular span. This may or may not be the same as the trace id.
+* **Parent Span ID**: (64 bits) Unsigned 64-bit integer ID for a particular parent span.  This is an optional ID that will only be present on child spans. That is the span without a parent id is considered the root of the trace. (Not present if P flag is not set)

--- a/Extensions/Well-Known-MIME-Types.md
+++ b/Extensions/Well-Known-MIME-Types.md
@@ -47,4 +47,5 @@ All well-known MIME types assume UTF-8 character encoding wherever a character s
 | `video/H265` | `36`
 | `video/VP8` | `37`
 | |
+| `message/x.rsocket.tracing-zipkin.v0` | `125`
 | `message/x.rsocket.composite-metadata.v0` | `127`

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Artifacts include:
 - Protocol Extensions
   - [Well-known MIME Types](Extensions/Well-Known-MIME-Types.md)
   - [Composite Metdata](Extensions/CompositeMetadata.md)
+  - [Tracing (Zipkin)](Extensions/Tracing-Zipkin.md)
 - [Motivation for creating this protocol](Motivations.md)
 - [Frequently Asked Questions](FAQ.md)
 


### PR DESCRIPTION
This change adds an extension specification for distributed tracing in the Zipkin format.

> Observability and tracing are key requirements for robust and reliable applications.  When using distributed applications connected with RSocket, it's important to propagate metadata about the current logical operations throughout the entire system.  One of the most popular systems for doing this kind of tracing is [Zipkin][z].  This extension specification provides an interoperatble structure for Zipkin metadata payloads to contain tracing information.  It is designed such that systems can efficently communicate span and trace information to a Zipkin server and propagate that information throughout a distributed system.

[z]: https://zipkin.io