### PR TITLE
64-bit Trace Id

### DIFF
--- a/Extensions/Tracing-Zipkin.md
+++ b/Extensions/Tracing-Zipkin.md
@@ -8,7 +8,7 @@ Observability and tracing are key requirements for robust and reliable applicati
 [z]: https://zipkin.io
 
 ## Metadata Payload
-This metadata type is intended to be used per stream, and not per connection nor individual payloads and as such it  **MUST** only be used in frame types used to initiate interactions and payloads.  This includes [`REQUEST_FNF`][rf], [`REQUEST_RESPONSE`][rr], [`REQUEST_STREAM`][rs], [`REQUEST_CHANNEL`][rc], and [`PAYLOAD`][p].  The Metadata MIME Type is `message/x.rsocket.tracing-zipkin.v0`.
+This metadata type is intended to be used per stream, and not per connection nor individual payloads and as such it **MUST** only be used in frame types used to initiate interactions and payloads.  This includes [`REQUEST_FNF`][rf], [`REQUEST_RESPONSE`][rr], [`REQUEST_STREAM`][rs], [`REQUEST_CHANNEL`][rc], and [`PAYLOAD`][p].  The Metadata MIME Type is `message/x.rsocket.tracing-zipkin.v0`.
 
 [p]:  ../Protocol.md#frame-payload
 [rc]: ../Protocol.md#frame-request-channel
@@ -21,8 +21,8 @@ This metadata type is intended to be used per stream, and not per connection nor
      0                   1                   2                   3
      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |P|S  |D  |     |
-    +-+---+---+-----------------------------------------------------+
+    |T|P|S  |D  |   |
+    +-+-+---+---+---+-----------------------------------------------+
     |                                                               |
     +                                                               +
     |                                                               |
@@ -42,13 +42,14 @@ This metadata type is intended to be used per stream, and not per connection nor
 ```
 
 * **Flags**: (8 bits)
+  * (**T**)race Id Size: Unset indicates that the Trace Id is 64-bit. Set indicates that the Trade Id is 128-bit.
   * (**P**)arent Span Id: Tracing payload contains a parent span id.
   * (**S**)ampling Decision (2 bits): Tracing payload contains a sample value. (Exclusive with D flag.)
     * First bit indicates if a sampling decision is present
-    * Second bit indicates that the span should be reported to the tracing system. (Not present if first bit is not set)
+    * Second bit indicates that the span should be reported to the tracing system. (Ignored if first bit is not set)
   * (**D**)ebug (2 bits): Tracing payload contains a debug value. (Exclusive with S flag.)
     * First bit indicates if a debug decision is present
-    * Second bit indicates that the trace should be reported to the tracing system and also override any collection-tier sampling policy. Debug implies an accept sampling decision. (Not present if the first bit is not set)
-* **Trace ID**: (128 bits) Unsigned 128-bit integer ID of the trace. Every span in a trace shares this ID.
+    * Second bit indicates that the trace should be reported to the tracing system and also override any collection-tier sampling policy. Debug implies an accept sampling decision. (Ignored if the first bit is not set)
+* **Trace ID**: (64 or 128 bits) Unsigned 64- or 128-bit integer ID of the trace. Every span in a trace shares this ID.
 * **Span ID**: (64 bits) Unsigned 64-bit integer ID for a particular span. This may or may not be the same as the trace id.
 * **Parent Span ID**: (64 bits) Unsigned 64-bit integer ID for a particular parent span.  This is an optional ID that will only be present on child spans. That is the span without a parent id is considered the root of the trace. (Not present if P flag is not set)


### PR DESCRIPTION
Previously the extension specification assumed that all trace ids would be 128-bit values.  In the discussion of #256 it was highlighted that not only was this variable between 64-bit and 128-bit, but the primary behavior is 64-bit values.  This change updates the specification to add a new T flag that indicates whether the value is a 64-bit value (unset) or a 128-bit value (set).  This removes the need to pad 64-bit values and ensures the efficiency in the data structure.