### PR TITLE
Provides addition to QoS and Prioritisation

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -1228,10 +1228,9 @@ A Responder that receives a REQUEST that it can not honor due to LEASE restricti
 <a name="flow-control-qos"></a>
 #### QoS and Prioritization
 
-Quality of Service and Prioritization of all *non Stream ID 0* streams (all application level streams) are considered application or network layer concerns and are better dealt with
-at those layers. The metadata capabilities, including METADATA_PUSH, are tools that applications can use for effective prioritization.
+Quality of Service and Prioritization of streams are considered application or network layer concerns and are better dealt with at those layers. The metadata capabilities, including METADATA_PUSH, are tools that applications can use for effective prioritization.
 
-However, all the frames within the *Stream ID 0* **SHOULD** be considered as *highly-prioritized* frames and delivered to the connection as soon as possible, since all the related frames impact directly or indirectly the stability and performance of the system in total.
+Within a single stream, the frames have to be processed in the order. However, frames with *Stream ID 0* **SHOULD** have a higher priority depending on the implementation, since all those frames impact directly or indirectly the stability and performance of the system in total.
 
 DiffServ via IP QoS are best handled by the underlying network layer protocols.
 

--- a/Protocol.md
+++ b/Protocol.md
@@ -1228,8 +1228,11 @@ A Responder that receives a REQUEST that it can not honor due to LEASE restricti
 <a name="flow-control-qos"></a>
 #### QoS and Prioritization
 
-Quality of Service and Prioritization of streams are considered application or network layer concerns and are better dealt with
+Quality of Service and Prioritization of all non zero streams (all application level streams) are considered application or network layer concerns and are better dealt with
 at those layers. The metadata capabilities, including METADATA_PUSH, are tools that applications can use for effective prioritization.
+
+However, all the frames within the *Stream ID 0* **SHOULD** be considered as *highly-prioritized* frames and delivered to the connection as soon as possible. That is not necessarily a mandated part of the implementation, but a RECOMENDED one since all the related frames impact the stability and performance of the system in total.
+
 DiffServ via IP QoS are best handled by the underlying network layer protocols.
 
 ### Handling the Unexpected

--- a/Protocol.md
+++ b/Protocol.md
@@ -1230,7 +1230,7 @@ A Responder that receives a REQUEST that it can not honor due to LEASE restricti
 
 Quality of Service and Prioritization of streams are considered application or network layer concerns and are better dealt with at those layers. The metadata capabilities, including METADATA_PUSH, are tools that applications can use for effective prioritization.
 
-Within a single stream, the frames have to be processed in the order. However, frames with *Stream ID 0* **SHOULD** have a higher priority depending on the implementation, since all those frames impact directly or indirectly the stability and performance of the system in total.
+Within a single stream, the frames have to be processed in order, but this is not the case between different streams. Frames with *Stream ID 0* **SHOULD** have a higher priority (*this is implementation specific*), since all those frames may impact the performance of the system.
 
 DiffServ via IP QoS are best handled by the underlying network layer protocols.
 

--- a/Protocol.md
+++ b/Protocol.md
@@ -1228,7 +1228,7 @@ A Responder that receives a REQUEST that it can not honor due to LEASE restricti
 <a name="flow-control-qos"></a>
 #### QoS and Prioritization
 
-Quality of Service and Prioritization of all non zero streams (all application level streams) are considered application or network layer concerns and are better dealt with
+Quality of Service and Prioritization of all *non Stream ID 0* streams (all application level streams) are considered application or network layer concerns and are better dealt with
 at those layers. The metadata capabilities, including METADATA_PUSH, are tools that applications can use for effective prioritization.
 
 However, all the frames within the *Stream ID 0* **SHOULD** be considered as *highly-prioritized* frames and delivered to the connection as soon as possible. That is not necessarily a mandated part of the implementation, but a RECOMENDED one since all the related frames impact the stability and performance of the system in total.

--- a/Protocol.md
+++ b/Protocol.md
@@ -1231,7 +1231,7 @@ A Responder that receives a REQUEST that it can not honor due to LEASE restricti
 Quality of Service and Prioritization of all *non Stream ID 0* streams (all application level streams) are considered application or network layer concerns and are better dealt with
 at those layers. The metadata capabilities, including METADATA_PUSH, are tools that applications can use for effective prioritization.
 
-However, all the frames within the *Stream ID 0* **MUST** be considered as *highly-prioritized* frames and delivered to the connection as soon as possible, since all the related frames impact directly or indirectly the stability and performance of the system in total.
+However, all the frames within the *Stream ID 0* **SHOULD** be considered as *highly-prioritized* frames and delivered to the connection as soon as possible, since all the related frames impact directly or indirectly the stability and performance of the system in total.
 
 DiffServ via IP QoS are best handled by the underlying network layer protocols.
 

--- a/Protocol.md
+++ b/Protocol.md
@@ -1231,7 +1231,7 @@ A Responder that receives a REQUEST that it can not honor due to LEASE restricti
 Quality of Service and Prioritization of all *non Stream ID 0* streams (all application level streams) are considered application or network layer concerns and are better dealt with
 at those layers. The metadata capabilities, including METADATA_PUSH, are tools that applications can use for effective prioritization.
 
-However, all the frames within the *Stream ID 0* **SHOULD** be considered as *highly-prioritized* frames and delivered to the connection as soon as possible. That is not necessarily a mandated part of the implementation, but a RECOMENDED one since all the related frames impact the stability and performance of the system in total.
+However, all the frames within the *Stream ID 0* **MUST** be considered as *highly-prioritized* frames and delivered to the connection as soon as possible, since all the related frames impact directly or indirectly the stability and performance of the system in total.
 
 DiffServ via IP QoS are best handled by the underlying network layer protocols.
 


### PR DESCRIPTION
This PR provides an update to the spec, which mentions a Recommendation for all implementations. Basically, it adds a note on prioritized delivering of all the *Stream ID 0* frames in case it is possible.

For example, in RSocket-Java, we have a [Queue](https://github.com/rsocket/rsocket-java/blob/develop/rsocket-core/src/main/java/io/rsocket/internal/UnboundedProcessor.java), which basically enqueues all the frames on the Requester level first, and the underlying duplex connection drains them and delivers later on. It means that the KeepAlive frame as an important one could be [stacked](https://github.com/rsocket/rsocket-java/pull/718) in that `Queue` and delayed in its delivery to the connection and subsequently to the Responder.

Undelivered on time KeepAlive frame could cause unwanted connection close event, which in that case is a false-positive action.

The same relates to Lease, Metadata_Push frames which bring emerging information about peers connected via the network.

See also #279 