### PR TITLE
Fixes bit length in Simple Auth payload

### DIFF
--- a/Extensions/Security/Simple.md
+++ b/Extensions/Security/Simple.md
@@ -16,7 +16,7 @@ Authentication is a necessary component to any real world application. The most 
     +---------------+-----------------------------------------------+
 ```
 
-* **Username Length**: (8 bits = max value 2^8 = 256) Unsigned 8-bit integer of Username Length in bytes.
+* **Username Length**: (8 bits = max value 2^8-1 = 255) Unsigned 8-bit integer of Username Length in bytes.
 * **Username**:  The UTF-8 encoded username.  The string MUST NOT be null terminated.
 * **Password**:  The UTF-8 encoded password.  The string MUST NOT be null terminated.
 

--- a/Extensions/Security/Simple.md
+++ b/Extensions/Security/Simple.md
@@ -16,7 +16,7 @@ Authentication is a necessary component to any real world application. The most 
     +---------------+-----------------------------------------------+
 ```
 
-* **Username Length**: (7 bits = max value 2^7 = 128) Unsigned 7-bit integer of Username Length in bytes.
+* **Username Length**: (8 bits = max value 2^8 = 256) Unsigned 8-bit integer of Username Length in bytes.
 * **Username**:  The UTF-8 encoded username.  The string MUST NOT be null terminated.
 * **Password**:  The UTF-8 encoded password.  The string MUST NOT be null terminated.
 


### PR DESCRIPTION
Looks like it either type in frame representation or frame description :

1) Frame says 8 bits (from 0 bit to 7 bit) where 
2) The description says 7 bits

From my point of view, there is no sense to limit Username length to 128 bits, so it should be fine to have 8 bits for the Username length field