### PR TITLE
Clarify Metadata Length

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -216,7 +216,7 @@ On a frame that only has Metadata, the Metadata length field is NOT needed:
 ```
 
 
-* __Metadata Length__: (24 bits = max value 16,777,215) Unsigned 24-bit integer representing the length of Metadata in bytes. Excluding Metadata Length field.
+* __Metadata Length__: (24 bits = max value 2^24-1 = max value 16,777,215) Unsigned 24-bit integer representing the length of Metadata in bytes. Excluding Metadata Length field. Value MUST be > 0.
 
 <a name="stream-identifiers"></a>
 ### Stream Identifiers

--- a/Protocol.md
+++ b/Protocol.md
@@ -216,7 +216,7 @@ On a frame that only has Metadata, the Metadata length field is NOT needed:
 ```
 
 
-* __Metadata Length__: (24 bits = max value 2^24-1 = max value 16,777,215) Unsigned 24-bit integer representing the length of Metadata in bytes. Excluding Metadata Length field. Value MUST be > 0.
+* __Metadata Length__: (24 bits = max value 2^24-1 = 16,777,215) Unsigned 24-bit integer representing the length of Metadata in bytes. Excluding Metadata Length field. Value MUST be > 0.
 
 <a name="stream-identifiers"></a>
 ### Stream Identifiers


### PR DESCRIPTION
I would like to add clarification to the metadata length field since right now it seems that 0 metadata length is a valid one but it makes no sense especially when we have a separate metadata flag field to indicate metadata presence.

I guess this wording was missed by mistake when #229 was merged and I don't see any reasons to have metadata flag present along with ZERO metadata encoded (which means 24 bits are just occupied for nothing).

Also, I would like to pay everyone's attention to `2^24-1` which is less convincing when we know for sure 0 is impossible (zero is disallowed, so we can have a little longer range), BUT this is done strictly for *backward* compatibility and in any case, it is impossible to have `2^24-1` bits encoded since metadata length MUST be strictly less than MAX frame length according to #232