### PR TITLE
adds Cap’n Proto and FlatBuffers to WellKnownMimeTypes

### DIFF
--- a/Extensions/WellKnownMimeTypes.md
+++ b/Extensions/WellKnownMimeTypes.md
@@ -49,8 +49,8 @@ All well-known MIME types assume UTF-8 character encoding wherever a character s
 | `application/x-hessian` | `0x26`
 | `application/x-java-object` | `0x27`
 | `application/cloudevents+json` | `0x28`
-| `application/application/x-capnp` | `0x29`
-| `application/application/x-flatbuffers` | `0x2A`
+| `application/x-capnp` | `0x29`
+| `application/x-flatbuffers` | `0x2A`
 | |
 | `message/x.rsocket.mime-type.v0` | `0x7A`
 | `message/x.rsocket.accept-mime-types.v0` | `0x7b`

--- a/Extensions/WellKnownMimeTypes.md
+++ b/Extensions/WellKnownMimeTypes.md
@@ -49,6 +49,8 @@ All well-known MIME types assume UTF-8 character encoding wherever a character s
 | `application/x-hessian` | `0x26`
 | `application/x-java-object` | `0x27`
 | `application/cloudevents+json` | `0x28`
+| `application/application/x-capnp` | `0x29`
+| `application/application/x-flatbuffers` | `0x2A`
 | |
 | `message/x.rsocket.mime-type.v0` | `0x7A`
 | `message/x.rsocket.accept-mime-types.v0` | `0x7b`


### PR DESCRIPTION
Cap’n Proto and FlatBuffers  are high performance serialization library, and they should be included in WellKnownType, and especially useful to per stream DataMimeType, and text MimeType is too long for them because of performance.
