### PR TITLE
improves Fragmentation and Reassembly examples

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -949,11 +949,14 @@ When a PAYLOAD is fragmented, the Metadata MUST be transmitted completely before
 
 For example, a single PAYLOAD with 20MB of Metadata and 25MB of Data that is fragmented into 3 frames:
 
+##### Payload with `next` flag set
+
 ```
 -- PAYLOAD frame 1
 Frame length = 16MB
 (M)etadata present = 1
 (F)ollows = 1 (fragments coming)
+(N)ext = 1
 Metadata Length = 16MB
 
 16MB of METADATA
@@ -963,6 +966,7 @@ Metadata Length = 16MB
 Frame length = 16MB
 (M)etadata present = 1
 (F)ollows = 1 (fragments coming)
+(N)ext = 1
 Metadata Length = 4MB
 
 4MB of METADATA
@@ -972,10 +976,51 @@ Metadata Length = 4MB
 Frame length = 13MB
 (M)etadata present = 0
 (F)ollows = 0
+(N)ext = 1
 
 0MB of METADATA
 13MB of Data
 ```
+
+If the sender (Requester or Responder) wants to cancel sending a fragmented sequence, it MAY send a CANCEL frame without finishing delivery of the fragments. 
+
+##### Payload with `next` and `complete` flags set
+
+```
+-- PAYLOAD frame 1
+Frame length = 16MB
+(M)etadata present = 1
+(F)ollows = 1 (fragments coming)
+(N)ext = 1
+(C)omplete = 0
+Metadata Length = 16MB
+
+16MB of METADATA
+0MB of Data
+
+-- PAYLOAD frame 2
+Frame length = 16MB
+(M)etadata present = 1
+(F)ollows = 1 (fragments coming)
+(N)ext = 1
+(C)omplete = 0
+Metadata Length = 4MB
+
+4MB of METADATA
+12MB of Data
+
+-- PAYLOAD frame 3
+Frame length = 13MB
+(M)etadata present = 0
+(F)ollows = 0
+(N)ext = 1
+(C)omplete = 1
+
+0MB of METADATA
+13MB of Data
+```
+
+__Note__, `complete` flag MUST be set only in the last FRAME which does not have `follows` flag set to indicate that the whole sequence is a Payload with `next` and `complete` flags at the same time.
 
 If the sender (Requester or Responder) wants to cancel sending a fragmented sequence, it MAY send a CANCEL frame without finishing delivery of the fragments. 
 
@@ -986,6 +1031,8 @@ When REQUEST_RESPONSE, REQUEST_FNF, REQUEST_STREAM, or REQUEST_CHANNEL frames ne
 When fragmented, the Metadata MUST be transmitted completely before the Data. 
 
 For example, a single PAYLOAD with 20MB of Metadata and 25MB of Data that is fragmented into 3 frames:
+
+##### Request Response
 
 ```
 -- REQUEST_RESPONSE frame 1
@@ -1001,6 +1048,7 @@ Metadata Length = 16MB
 Frame length = 16MB
 (M)etadata present = 1
 (F)ollows = 1 (fragments coming)
+(N)ext = 1
 Metadata Length = 4MB
 
 4MB of METADATA
@@ -1010,10 +1058,50 @@ Metadata Length = 4MB
 Frame length = 13MB
 (M)etadata present = 0
 (F)ollows = 0
+(N)ext = 1
 
 0MB of METADATA
 13MB of Data
 ```
+
+If the Requester wants to cancel sending a fragmented sequence, it MAY send a CANCEL frame without finishing delivery of the fragments. 
+
+##### Request Channel with `complete` flag
+
+```
+-- REQUEST_CHANNEL frame 1
+Frame length = 16MB
+(M)etadata present = 1
+(F)ollows = 1 (fragments coming)
+(C)omplete = 0
+Metadata Length = 16MB
+
+16MB of METADATA
+0MB of Data
+
+-- PAYLOAD frame 2
+Frame length = 16MB
+(M)etadata present = 1
+(F)ollows = 1 (fragments coming)
+(N)ext = 1
+(C)omplete = 0
+Metadata Length = 4MB
+
+4MB of METADATA
+12MB of Data
+
+-- PAYLOAD frame 3
+Frame length = 13MB
+(M)etadata present = 0
+(F)ollows = 0
+(N)ext = 1
+(C)omplete = 1
+
+0MB of METADATA
+13MB of Data
+```
+
+__Note__, `complete` flag MUST be set only in the last FRAME which does not have `follows` flag set to indicate that the whole sequence is a Request Channel with `complete` flag.
 
 If the Requester wants to cancel sending a fragmented sequence, it MAY send a CANCEL frame without finishing delivery of the fragments. 
 


### PR DESCRIPTION
# Provide better examples for Fragmentation

### Motivation:

At the moment, fragmentation examples do not explain in details how every frame (including flags) should look like

### Modifications:

This PR adds flags to the example sequences as well as add cases when payload has next and complete flags and adds example for Request Channel which has complete flag

### Result:

Improved examples

Signed-off-by: Oleh Dokuka <odokuka@vmware.com>